### PR TITLE
[*] Get rid of pkg_resources for fiql_parser version.

### DIFF
--- a/fiql_parser/__init__.py
+++ b/fiql_parser/__init__.py
@@ -21,9 +21,10 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-import pkg_resources
+VERSION = (0, 15)
 #pylint: disable=no-member
-__version__ = pkg_resources.get_distribution("fiql_parser").version
+__version__ = VERSION
+__versionstr__ = '.'.join(map(str, VERSION))
 
 from .exceptions import FiqlException
 from .exceptions import FiqlObjectException, FiqlFormatException


### PR DESCRIPTION
pkg_resources shim is not available without installed setuptools. So initialization of fiql_parser fails.
In our case we use AWS lambda without pip and setuptools on it. This pull request contains a common versioning practice. 
